### PR TITLE
Added *.smod to Fortran.gitignore

### DIFF
--- a/C++.gitignore
+++ b/C++.gitignore
@@ -15,6 +15,7 @@
 
 # Fortran module files
 *.mod
+*.smod
 
 # Compiled Static libraries
 *.lai


### PR DESCRIPTION
**Reasons for making this change:**

GCC's gfortran 6 now generates .smod files for Fortran (2008+) submodules

**Links to documentation supporting these rule changes:** 

https://gcc.gnu.org/gcc-6/changes.html
